### PR TITLE
Correct the command for create a user in sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Sentry is now up and running on your domain ([https://sentry.example.com](#)).
 Before you're able to use it, you need to create a user.
 
 ```
-dokku run sentry web sentry createuser
+dokku run sentry sentry createuser
 ```
 
 This will prompt you to enter an email, password and whether the user should be a superuser.


### PR DESCRIPTION
At least in my case for create the user I need to change the command:

If I execute the old comamnd I get the error
```
jmenendez@instance-1:~$ dokku run sentry web sentry createuser
-----> Found 'web' in Procfile, running that command
/entrypoint.sh: line 26: exec: uwsgi --ini=uwsgi.ini --http=0.0.0.0:9000: not found
```

Using Dokku 0.11.6

