### PR TITLE
Upgrade to Sentry 9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sentry:9.0-onbuild
+FROM sentry:9.1-onbuild
 
 RUN groupadd -r dokku && useradd -r -m -u 32768 -g dokku dokku
 USER dokku

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Project logo](.github/header.png)
 
-![Sentry version](https://img.shields.io/badge/Sentry-9.0-blue.svg) ![Dokku version](https://img.shields.io/badge/Dokku-v0.12.10-blue.svg)
+![Sentry version](https://img.shields.io/badge/Sentry-9.1-blue.svg) ![Dokku version](https://img.shields.io/badge/Dokku-v0.14.6-blue.svg)
 
 # Run Sentry on Dokku
 
@@ -14,7 +14,7 @@ modifications for a seamless deploy to Dokku.
 ## What you get
 
 This repository will deploy [Sentry
-9.0](https://github.com/getsentry/sentry/releases/tag/9.0.0). It has been tested
+9.01(https://github.com/getsentry/sentry/releases/tag/9.1.0). It has been tested
 with Dokku 0.10+.
 
 ## Requirements
@@ -27,7 +27,7 @@ with Dokku 0.10+.
 
 # Upgrading
 
-When upgrading to a newer version, e.g. 8.22 to 9.0.0, you just need to follow
+When upgrading to a newer version, e.g. 8.22 to 9.1.0, you just need to follow
 the following steps:
 
 First get the newest version of this repository from GitHub and push it to you

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # WSGI handler
-uWSGI==2.0.17.1
+uWSGI==2.0.18
 
 # Sentry plugins
-sentry-plugins==9.0.0
+sentry-plugins==9.1.0
 
 # Environment variables for Django
 django-environ==0.4.5


### PR DESCRIPTION
Upgrades the repository to [Sentry 9.1](https://github.com/getsentry/sentry/releases/tag/9.1.0). 